### PR TITLE
docs: expand architecture and add bisection data model

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Please drop them into `contrib/` with a short README describing
 what they do and how they work.
 
 See the [GitHub issues](../../issues) for the current roadmap and
-discussion topics.
+discussion topics. Design sketch in
+[docs/architecture.md](docs/architecture.md); unresolved design
+questions in [oq.md](oq.md).
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -2,25 +2,40 @@
 
 A generic toolbox for automated Linux kernel bisection.
 
-This project provides composable building blocks for bisecting kernel
-regressions — build failures, boot failures, and test failures. The
-components are designed to be usable standalone or integrated into CI
+This project provides composable building blocks for bisecting kernel issues of
+the different types, for example:
+
+- build failures
+- boot failures
+- configuration failures
+- unit test failures
+- performance regressions
+
+The components are designed to be usable standalone or integrated into CI
 systems such as [KernelCI](https://kernelci.org).
 
 ## Status
 
-**Early development.** We are collecting existing bisection scripts and
-tools from multiple organisations and refactoring them into reusable
+**Early development.** We are collecting existing bisection tools and
+approaches from multiple organisations and refactoring them into reusable
 components. Contributions are welcome.
 
 ## Goals
 
-- Generic bisection framework not tied to any single CI system
-- Composable building blocks: build, test, cache, result parsing, reporting
+- Generic bisection framework
+- Composable building blocks: 
+  - build
+  - test
+  - cache
+  - results parsing
+  - results verification
+  - results analysis
+  - reporting
 - Support for reproducible builds ([TuxMake](https://tuxmake.org)) and
   tests ([TuxRun](https://tuxrun.org))
 - Pluggable backends for build and test execution
-- Usable both as a CLI tool and as a library
+- Pluggable frontends for reporting
+- Usable both as a CLI tool(s) and as a library
 
 ## Repository structure
 
@@ -33,8 +48,8 @@ kci-bisect/
 
 ## Contributing
 
-We are actively looking for existing bisection scripts, wrappers, and
-tools. Please drop them into `contrib/` with a short README describing
+We are actively looking for existing bisection tools.
+Please drop them into `contrib/` with a short README describing
 what they do and how they work.
 
 See the [GitHub issues](../../issues) for the current roadmap and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,8 +37,22 @@ interfaces and boundaries are TBD.
 
 - **Test step** — runs a test against a built kernel
   - Backends: TuxRun (QEMU), LAVA (hardware), custom
-- **Result parser** — determines pass/fail from test output
+- **Result parser** — extracts structured signals from test output
+  (pass/fail flags, error signatures, measured metrics). Deterministic
+  extraction only; no verdict.
   - Integration: logspec for error signature matching
+
+### Decision Engine
+
+- **Decision Engine** — maps parsed signals to a bisection verdict:
+  `good` / `bad` / `skip` / `weak`. Separated from `Result parser` so that policy (thresholds, confidence, etc) can evolve independently of signal extraction.
+  - Strategies:
+    - **binary** — presence/absence of an error signature
+      (build, boot, config, unit-test failures)
+    - **threshold / statistical** — regression decision on a continuous
+      metric, possibly over multiple repetitions (performance)
+  - `skip` (cannot test at this commit, e.g. build broken pre-existing)
+    is distinct from `weak` (tested but evidence uncertain)
 
 ### Reporting
 
@@ -52,18 +66,26 @@ interfaces and boundaries are TBD.
 
 - **Verify step** — confirms the suspect commit by reverting and retesting
 
+### State
+
+- **State store** — persists bisection progress for auditability and
+  resumability. Data model:
+  - **Campaign** — one bisection investigation, bounded by a fixed
+    scope and known good/bad boundaries
+  - **Step** — one tested commit inside a campaign; records tested
+    commit, build and test evidence, decision
+    (`good` / `bad` / `skip` / `weak`), and rationale.
+  - Backends: local file (JSON, SQLite), KCIDB, custom
+
 ## Integration Points
 
 These are KernelCI-specific and should be separate from the generic core:
 
-- Maestro regression detection → bisection trigger
-- Maestro /api/checkout → build + test execution
-- KCIDB → historical result lookup
-- kci-dev CLI → developer-facing interface
+- [Maestro](https://docs.kernelci.org/components/maestro/) regression detection -> bisection trigger
+- Maestro /api/checkout -> build + test execution
+- KCIDB -> historical result lookup
+- kci-dev CLI-> developer-facing interface
 
 ## Open Questions
 
-- How to handle non-linear git history (merge commits)?
-- How to handle flaky/intermittent test failures?
-- What state needs to be persisted for resumable bisections?
-- Align with Guillaume's Renelec/Vixie framework?
+List of open questions is tracked in [../oq.md](../oq.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,11 @@
 2. **Composable** — building blocks that can be assembled differently
 3. **Pluggable backends** — swap build/test/storage backends
 4. **Reproducible** — deterministic builds and tests across bisection steps
+5. **Reuse over reinvention** — wrap existing open-source tools
+   (TuxMake, TuxRun, LAVA, git-bisect, logspec, ...) behind the
+   component interfaces rather than reimplementing them. Define the
+   interface first so tool choice stays swappable; contribute upstream
+   over forking.
 
 ## Proposed Building Blocks
 

--- a/docs/bisection-data-model.md
+++ b/docs/bisection-data-model.md
@@ -1,0 +1,79 @@
+# Bisection Data Model
+
+Reference data model for the State store (see [architecture.md](./architecture.md)).
+
+Each bisection campaign fixes a set of dimensions so that the kernel commit is the only changing variable.
+Which dimensions matter depends on the failure type:
+
+| Failure type | Fixed-scope dimensions |
+|---|---|
+| Build | arch, defconfig, toolchain, compiler version |
+| Boot | arch, defconfig, toolchain, device/VM |
+| Config | arch, base defconfig, toolchain |
+| Unit-test | arch, defconfig, toolchain, test suite, test case |
+| Performance | SUT profile, workload config, measured workload, metric, repetition structure |
+
+The model below uses "campaign-scope fields" to refer to whichever set of dimensions applies 
+to the campaign's failure type.
+
+## Records
+
+Bisection defines the records used after regression detection to isolate the kernel change
+that caused an observed regression. Bisection tests builds within a fixed comparability scope
+until the regression is isolated to one culprit commit, narrowed to a range, or judged unresolved.
+
+A `build` is a compiled snapshot of the kernel source at a specific commit with a specific
+configuration and toolchain. Bisection tests builds, not source; the kernel commit is the only
+intended changing variable across builds in one campaign.
+
+### Bisection Campaigns
+
+Bisection Campaign represents one bounded investigation for isolating a detected regression.
+
+One bisection campaign starts from already detected and classified regression evidence or 
+grouped case built from classified regressions.
+This entry is the durable record of one bisection workflow, linking the triggering evidence,
+the fixed scope, and the steps performed.
+
+A bisection campaign may conclude in different ways. It may isolate one culprit build,
+narrow the regression to a smaller commits range, remain unresolved because the evidence is 
+inconsistent or incomplete, or end with the conclusion that the originally suspected regression
+could not be reproduced under the fixed campaign scope.
+
+The entry contains:
+
+- `Bisection-campaign record ID`: one regression-isolation workflow.
+- `Evidence links`: the records that caused the bisection campaign to start.
+- `Campaign-scope fields`: the fixed dimensions for this campaign's failure type that must remain constant.
+- `Search-boundary fields`: the known-good boundary, the known-bad boundary, and the search method.
+- `Lifecycle fields`: the campaign status, start/end times, and the actor responsible for compaign.
+- `Final-outcome fields`: the final conclusion of the campaign, including the outcome category (single culprit
+    identified, narrowed range, unresolved, or original regression not confirmed), the culprit kernel reference
+    when a single kernel is identified, and the narrowed good and bad boundary references when the outcome 
+    is a narrowed range.
+- `Bisection-step links`: the ordered tested steps that belong to that campaign.
+
+### Bisection Steps
+
+Bisection Step represents one tested build inside one bisection campaign.
+
+Each step records the build that was tested (commit plus configuration
+and toolchain), the evidence produced, and the decision derived from
+that evidence. Steps form the ordered audit trail of one campaign.
+
+A step does not have to end with a clean good-or-bad decision. Some steps are `skip` because the build
+failed or could not run, and some are `weak` because the evidence is too noisy or incomplete.
+
+The entry contains:
+
+- `Bisection-step record ID`: one tested build inside one bisection campaign.
+- `Bisection-campaign reference`: the campaign this step belongs to.
+- `Step-order fields`: the order of the step inside the workflow and the position of the
+   tested commit relative to the current search boundaries.
+- `Kernel reference`: the kernel commit tested at that step.
+- `Build reference`: the concrete build provenance (commit, arch, defconfig,
+   toolchain) used for that tested step.
+- `Step-evidence links`: the comparison and analysis records between the tested build and a reference build.
+- `Step-decision result`: the step result: `good`, `bad`, `skip`, or `weak`.
+- `Step-rationale fields`: why that result was recorded — which evidence supported `good`/`bad`,
+   which failure caused `skip`, or which uncertainty caused `weak`.

--- a/oq.md
+++ b/oq.md
@@ -1,0 +1,60 @@
+# Open Questions
+
+Design questions that are not yet resolved. Each should either become a
+decision recorded in `docs/<file>` or be closed as out-of-scope.
+
+## Scope & Semantics
+
+1. What are the "fixed scope" dimensions of a bisection campaign for each failure type?
+   Performance regressions need SUT profile, workload, metric, and repetition structure held constant.
+   Build failures need arch, defconfig, toolchain.
+   What is the minimum common set, and what is type-specific?
+
+2. Shared Decision Engine interface for binary signals (build/boot/test failures)
+  and continuous metrics (performance), or two strategies behind one interface?
+
+3. Keep `skip` and `weak` as distinct step outcomes, or collapse to `git bisect`'s single `skip`?
+   They drive different follow-ups: skip advances the search; weak suggests re-test.
+
+4. What counts as "triggering evidence" generically? A regression classification, a first-red build,
+   a user-filed bug?
+
+## Git & Commit Selection
+
+1. How to handle non-linear git history (merge commits)?
+2. Cherry-picks and rebases: the "same" change has different SHAs across trees. How does the cache disambiguate?
+3. What is the source-tree state for the cache key — commit alone, or commit plus applied patches / reverts?
+
+## Flakiness & Reliability
+
+1. How to handle flaky / intermittent test failures? N-of-M retry, statistical test, re-run on different hardware?
+2. Who owns flakiness mitigation — Decision Engine, Scheduler, or Test step?
+3. What timeout and resource-budget policy per build, per test, and per bisection campaign?
+
+## State & Resumability
+
+1. Which backend(s) to support first — local JSON, SQLite, KCIDB?
+2. How is a step represented when the process crashes mid-run?
+
+## Concurrency
+
+1. N-bisect implies parallel build+test; who schedules, reconciles partial failures, and decides when
+   enough evidence is in?
+2. Upper bound on parallelism and interaction with cache warming?
+
+## Verification
+
+1. Is "revert and retest" the only strategy?
+   Candidates: re-test on different hardware, statistical re-test for flakes, apply-on-known-good 
+   to confirm the change introduces the failure.
+
+## Integration
+
+1. How are credentials / secrets for backend APIs (LAVA, Maestro, KCIDB, mail servers) handled?
+2. What is the minimal generic input contract (good commit, bad commit, build command, test command,
+   decision engine config) that works without KernelCI?
+
+## Reporting
+
+1. Is the kernel-specific recipient resolution (`get_maintainers.pl`, commit trailers, Lore mbox) part
+   of the core or an integration plugin?


### PR DESCRIPTION
- Add "Reuse over reinvention" principle to the architecture doc.
- Introduce Decision Engine (separates verdict policy from signal extraction) and State store components.
- Track unresolved design questions in `oq.md`, linked from README  and architecture doc.
- Add `docs/bisection-data-model.md`: Campaign/Step reference model.